### PR TITLE
fix : Sync error after VCS push in Studio

### DIFF
--- a/src/project-sync.service.js
+++ b/src/project-sync.service.js
@@ -110,9 +110,9 @@ async function downloadProject(projectId, config, projectDir) {
 }
 
 async function gitResetAndPull(tempDir, projectDir){
-    await exec('git', ['reset', '--hard', 'master'], {cwd: projectDir});
     await exec('git', ['clean', '-fd'], {cwd: projectDir});
-    await exec('git', ['pull', path.join(tempDir, 'remoteChanges.bundle'), 'master'], {cwd: projectDir});
+    await exec('git', ['fetch', path.join(tempDir, 'remoteChanges.bundle'), 'refs/heads/master'], {cwd: projectDir});
+    await exec('git', ['reset', '--hard', 'FETCH_HEAD'], {cwd: projectDir});
 }
 
 async function pullChanges(projectId, config, projectDir) {


### PR DESCRIPTION
Resolved a divergent branch error encountered during sync after a VCS push in Studio. The issue was addressed by updating the HEAD pointer to the latest FETCH_HEAD.