### PR TITLE
chore: update Podfile dynamically if `useFrameworks` is set to static in app.json

### DIFF
--- a/src/ios.js
+++ b/src/ios.js
@@ -12,6 +12,7 @@ const {
     validateForIos
  } = require('./requirements');
  const { readAndReplaceFileContent, iterateFiles } = require('./utils');
+ const { newPostInstallBlock } =  require('../templates/ios-build-patch/podFIlePostInstall');
 
  const loggerLabel = 'Generating ipa file';
 
@@ -150,46 +151,6 @@ async function embed(args) {
     });
 }
 
-const newPostInstallBlock = `
-post_install do |installer|
-  react_native_post_install(
-    installer,
-    config[:reactNativePath],
-    :mac_catalyst_enabled => false
-  )
-
-  # Set provisioning profile to "None" for all pod targets
-  installer.pods_project.targets.each do |target|
-    target.build_configurations.each do |config|
-      config.build_settings['PROVISIONING_PROFILE'] = 'None'
-      config.build_settings['CODE_SIGN_IDENTITY'] = ''
-      config.build_settings['CODE_SIGNING_ALLOWED'] = 'NO' 
-    end
-  end
-
-  # Disable code signing for resource bundle targets
-  installer.target_installation_results.pod_target_installation_results
-    .each do |pod_name, target_installation_result|
-    target_installation_result.resource_bundle_targets.each do |resource_bundle_target|
-      resource_bundle_target.build_configurations.each do |config|
-        config.build_settings['CODE_SIGNING_ALLOWED'] = 'NO'
-        config.build_settings['PROVISIONING_PROFILE'] = 'None' 
-        config.build_settings['CODE_SIGN_IDENTITY'] = '' 
-      end
-    end
-  end
-end
-
-  post_integrate do |installer|
-    begin
-      expo_patch_react_imports!(installer)
-    rescue => e
-      Pod::UI.warn e
-    end
-  end
-end
-`;
-
 async function invokeiosBuild(args) {
     const certificate = args.iCertificate;
     const certificatePassword = args.iCertificatePassword;
@@ -257,7 +218,8 @@ async function invokeiosBuild(args) {
                 const iosConfig = buildPropertiesPlugin[1].ios;
                 if (iosConfig && iosConfig.useFrameworks === 'static'){
                     await readAndReplaceFileContent(`${config.src}ios/Podfile`, (podfileContent) => {
-                        const modifiedPodContent = podfileContent.replace(/post_install do \|installer\|.+?^end\s*$/ms, newPostInstallBlock);
+                        const postInstallRegex = /post_install\s+do\s+\|installer\|[\s\S]*?react_native_post_install\([\s\S]*?\)[\s\S]*?(?=post_integrate|$)/;
+                        const modifiedPodContent = podfileContent.replace(postInstallRegex, newPostInstallBlock);
                         return modifiedPodContent;
                     });
                 }

--- a/templates/ios-build-patch/podFIlePostInstall.js
+++ b/templates/ios-build-patch/podFIlePostInstall.js
@@ -1,0 +1,34 @@
+const newPostInstallBlock = `
+post_install do |installer|
+  react_native_post_install(
+    installer,
+    config[:reactNativePath],
+    :mac_catalyst_enabled => false
+  )
+
+  # Set provisioning profile to "None" for all pod targets
+  installer.pods_project.targets.each do |target|
+    target.build_configurations.each do |config|
+      config.build_settings['PROVISIONING_PROFILE'] = 'None'
+      config.build_settings['CODE_SIGN_IDENTITY'] = ''
+      config.build_settings['CODE_SIGNING_ALLOWED'] = 'NO' 
+    end
+  end
+
+  # Disable code signing for resource bundle targets
+  installer.target_installation_results.pod_target_installation_results
+    .each do |pod_name, target_installation_result|
+    target_installation_result.resource_bundle_targets.each do |resource_bundle_target|
+      resource_bundle_target.build_configurations.each do |config|
+        config.build_settings['CODE_SIGNING_ALLOWED'] = 'NO'
+        config.build_settings['PROVISIONING_PROFILE'] = 'None' 
+        config.build_settings['CODE_SIGN_IDENTITY'] = '' 
+      end
+    end
+  end
+end
+`;
+
+module.exports = {
+  newPostInstallBlock
+}


### PR DESCRIPTION
**Update Podfile dynamically if `useFrameworks` is set to static in app.json**

- Disabled code signing for all pod and resource bundle targets in `post_install`.