### PR TITLE
bump: version from 1.8.9 to 1.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wavemaker/wm-reactnative-cli",
-  "version": "1.8.9",
+  "version": "1.9.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@wavemaker/wm-reactnative-cli",
-      "version": "1.8.9",
+      "version": "1.9.0",
       "license": "ISC",
       "dependencies": {
         "axios": "^0.24.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wavemaker/wm-reactnative-cli",
-  "version": "1.8.9",
+  "version": "1.9.0",
   "description": "",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
Changes:

1. bump package.json version from 1.8.9 to 1.9.0

2. bump package-lock.json version from 1.8.9 to 1.9.0